### PR TITLE
Deploy to Production: Fix errors on notes index

### DIFF
--- a/app/assets/stylesheets/note.scss
+++ b/app/assets/stylesheets/note.scss
@@ -1,0 +1,4 @@
+.primary-note-category {
+  color: #777;
+  margin: 4px 0 10px 0;
+}

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -30,7 +30,8 @@
     <h3 class="center-text top-and-bottom">Latest Notes</h3>
     <% @notes.each do |note| %>
     <div class="col-xs-6 list">
-      <p class="text-center"><%= link_to note.title, note_path(note) %> (<%= note.categories.first.title %>)</p>
+      <p class="text-center"><%= link_to note.title, note_path(note) %>
+        <%= note.categories.first.title if note.categories.first %></p>
     </div>
     <% end %>
     </div>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -10,9 +10,14 @@
 <div class="text-center col-xs-offset-1 col-xs-10 col-sm-offset-2 col-sm-8 col-md-offset-3 col-md-6">
   <h1><%= @note.title %></h1>
 </div>
-  <div class="col-xs-12">
-
+<% categories = @note.categories %>
+<% unless categories.empty? %>
+<div class="row">
+  <div class="col-xs-12 text-center">
+    <h4 class="primary-note-category"><%= categories.first.title %></h4>
   </div>
+</div>
+<% end %>
 </div>
 <div class="row">
   <div class="col-xs-offset-1 col-xs-10 col-sm-offset-2 col-sm-8 col-md-offset-3 col-md-6">
@@ -26,11 +31,13 @@
     </div>
   </div>
 </div>
-<div class="row">
-  <div class="col-xs-offset-1 col-xs-10 col-sm-offset-2 col-sm-8 col-md-offset-3 col-md-6">
-    <span>Other Categories: <%= @note.categories[1..-1].map(&:title).join(", ") %></span>
+<% if categories.count > 1 %>
+  <div class="row">
+    <div class="col-xs-offset-1 col-xs-10 col-sm-offset-2 col-sm-8 col-md-offset-3 col-md-6">
+      <span>Other Categories: <%= @note.categories[1..-1].map(&:title).join(", ") %></span>
+    </div>
   </div>
-</div>
+<% end %>
 <div class="row">
   <div class="col-xs-offset-1 col-xs-10 col-sm-offset-2 col-sm-8 col-md-offset-3 col-md-6 well">
     <p class="text-center">


### PR DESCRIPTION
Fixes bug that was causing an error in the notes `index` page as well as one in the notes `show` page. Also adds the display of a note's first category, if present, on the notes `show` page.
From Issue #7
