### PR TITLE
Deploy to Production: Fix page height

### DIFF
--- a/app/assets/stylesheets/welcome.scss
+++ b/app/assets/stylesheets/welcome.scss
@@ -7,6 +7,7 @@
 html, body {
   width: 100% !important;
   overflow-x: hidden !important;
+	height: 100%;
 }
 
 .container {


### PR DESCRIPTION
Fixes page height for pages where the content did not fill up the entire window to allow the note dropdown to be seen on every page.
From issue #9 
